### PR TITLE
Upgrade to 24.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Copy the files from the `template` directory to the root of the repository and e
 ## Building
 ```bash
 nix-build \
-    -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/9bc841f.tar.gz # nixos-unstable on 2022-03-23
+    -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/tags/24.11.tar.gz # nixos 24.11 on 2025-03-07
 ```
 
 ## Flashing

--- a/minification.nix
+++ b/minification.nix
@@ -2,9 +2,6 @@
 
 with lib;
 {
-  # no GUI environment
-  environment.noXlibs = mkDefault true;
-
   # don't build documentation
   documentation.info.enable = mkDefault false;
   documentation.man.enable = mkDefault false;

--- a/rpi-zero-w.nix
+++ b/rpi-zero-w.nix
@@ -1,23 +1,19 @@
 { config, lib, pkgs, ... }:
 
 {
-  boot = {
-    loader = {
-      grub.enable = false;
-      raspberryPi = {
-        enable = true;
-        version = 0;
-      };
-    };
+  # NixOS wants to enable GRUB by default
+  boot.loader.grub.enable = false;
+  # Enables the generation of /boot/extlinux/extlinux.conf
+  boot.loader.generic-extlinux-compatible.enable = true;
 
-    kernelPackages = pkgs.linuxPackages_rpi0;
-    consoleLogLevel = lib.mkDefault 7;
+  kernelPackages = pkgs.linuxPackages_rpi0;
+  consoleLogLevel = lib.mkDefault 7;
 
-    # prevent `modprobe: FATAL: Module ahci not found`
-    initrd.availableKernelModules = pkgs.lib.mkForce [
-      "mmc_block"
-    ];
-  };
+  # prevent `modprobe: FATAL: Module ahci not found`
+  initrd.availableKernelModules = pkgs.lib.mkForce [
+    "mmc_block"
+  ];
+};
 
   sdImage = {
     populateRootCommands = "";

--- a/sd-image.nix
+++ b/sd-image.nix
@@ -50,5 +50,5 @@
     '';
   };
 
-  system.stateVersion = "nixos-unstable";
+  system.stateVersion = "24.11";
 }

--- a/sd-image.nix
+++ b/sd-image.nix
@@ -27,16 +27,6 @@
 
   networking.wireless.enable = true;
 
-  boot = {
-    loader.raspberryPi.firmwareConfig = ''
-      dtparam=i2c=on
-    '';
-    kernelModules = [
-      "i2c-dev"
-    ];
-  };
-  hardware.i2c.enable = true;
-
   users = {
     extraGroups = {
       gpio = {};


### PR DESCRIPTION
Testing upgrade to 24.11 and various fixes 

       Failed assertions:
       - The option definition `environment.noXlibs' in `/home/antonio/dev/nixos-rpi-zero-w/minification.nix' no longer has any effect; please remove it.
       The environment.noXlibs option was removed, as it often caused surprising breakages for new users.
       If you need its functionality, you can apply similar overlays in your own config.


       - The option definition `boot.loader.raspberryPi' in `/home/antonio/dev/nixos-rpi-zero-w/rpi-zero-w.nix' and `/home/antonio/dev/nixos-rpi-zero-w/sd-image.nix' no longer has any effect; please remove it.
       The raspberryPi boot loader has been removed. See https://github.com/NixOS/nixpkgs/pull/241534 for what to use instead.

       - nixos-unstable is an invalid value for 'system.stateVersion'; it must be in the format "YY.MM",
       which corresponds to a prior release of NixOS.

       If you want to switch releases or switch to unstable, you should change your channel and/or flake input URLs only.
       *DO NOT* touch the 'system.stateVersion' option, as it will not help you upgrade.
       Leave it exactly on the previous value, which is likely the value you had for it when you installed your system.

       If you're unsure which value to set it to, use "25.05" as a default.